### PR TITLE
2.5.0 - shipping-simulator-for-woocommerce (AJustes para diretrizes do Wordpress)

### DIFF
--- a/classes/Request.php
+++ b/classes/Request.php
@@ -86,6 +86,10 @@ final class Request {
 	public function handle_form_request () {
 		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'POST' !== $_SERVER['REQUEST_METHOD'] ) return;
 
+		// REASON: Only react to the simulator's own no-JS fallback POST. Other POSTs on
+		// the same page (e.g. WooCommerce add-to-cart) must not trigger this notice.
+		if ( ! isset( $_POST['wc_shipping_simulator_submit'] ) ) return;
+
 		if ( current_user_can( 'manage_options' ) ) {
 			$this->form_notice = __( 'Your browser does not have JavaScript enabled or there are JavaScript errors preventing the shipping simulator from working. Check your browser console or disable other plugins to try to find any conflicts.', 'shipping-simulator-for-woocommerce' );
 		}

--- a/templates/shipping-simulator-form.php
+++ b/templates/shipping-simulator-form.php
@@ -2,6 +2,8 @@
 	<?php do_action( 'wc_shipping_simulator_wrapper_start' ) ?>
 
 	<form method="POST" enctype="application/x-www-form-urlencoded" id="wc-shipping-sim-form" data-params="<?php echo esc_attr( wp_json_encode( $params ) ) ?>">
+		<input type="hidden" name="wc_shipping_simulator_submit" value="1">
+
 		<?php do_action( 'wc_shipping_simulator_form_start' ) ?>
 
 		<div id="wc-shipping-sim-form-fields">


### PR DESCRIPTION
# Shipping Simulator for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/

Tags: woocommerce, shipping simulator, simulador de frete, calculadora de frete, product page

Testado até: 7.1

Versão estável: 2.5.0

Requer PHP: 8.2

Requer WordPress: 6.0

Licença: GPLv3

URI da Licença: http://www.gnu.org/licenses/gpl-3.0.html

Traduções: Português (Brasil) / Inglês

Permita que seus clientes calculem o frete diretamente na página do produto.

## Descrição

O Shipping Simulator for WooCommerce permite que os clientes calculem as opções de frete na página do produto, sem sair da página. Ele consulta as opções de entrega configuradas no WooCommerce e exibe o custo e o prazo estimado.

**Recursos Principais**

- Cálculo de frete direto na página do produto
- Cálculo sem a necessidade de selecionar variações (configurável)
- Preenchimento automático do endereço do cliente (configurável)
- Suporte a shortcode `[wc_shipping_simulator]` para uso com page builders
- Integrações: frete grátis, estimativa de prazo de entrega, autofill de endereços brasileiros (CEP), Melhor Envio
- Filtros (hooks) para personalização:
  - `wc_shipping_simulator_package_rates`
  - `wc_shipping_simulator_package_data`
  - `wc_shipping_simulator_request_response`
  - `wc_shipping_simulator_form_input_mask`
  - entre outros (prefixo `wc_shipping_simulator_*`)

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e ativado antes de usar o Shipping Simulator for WooCommerce.

**Instruções de uso**

1. Instale e ative o plugin (o WooCommerce deve estar ativo).
2. Acesse **WooCommerce → Configurações → Entrega → Shipping Simulator**.
3. Configure as opções de exibição, preenchimento de endereço e textos do simulador.
4. Para exibir o simulador em uma página específica (ex.: com page builder), use o shortcode `[wc_shipping_simulator]`.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para **Plugins → Adicionar Novo**.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin baixado.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG - 2.5.0

* Removido o aviso de doação exibido no painel administrativo
* Corrigidos os text-domains das strings para melhor suporte a traduções
* Requer WordPress 6.0+ e PHP 8.2+
* Ajustes de conformidade com as diretrizes da Link Nacional
